### PR TITLE
Added an alternative selector to keep compatibility with changes that will come with XWIKI-12824

### DIFF
--- a/application-xwebide-ui/src/main/resources/WebIDECode/WebIDE_class.xml
+++ b/application-xwebide-ui/src/main/resources/WebIDECode/WebIDE_class.xml
@@ -466,7 +466,7 @@ define(['jquery', 'bootstrap'], function($) {
           $(ifrm).contents().find('#menuview, #rightPanels, #leftPanels, .bottombuttons, #hierarchy, #footerglobal, .row, .leftmenu2').hide();
           $(ifrm).contents().find('#classname').parent().remove();
           $(ifrm).contents().find('#options').find('#updateClassSheet, #updateClassTranslations').attr('checked', false); // Basic mode only
-          $(ifrm).contents().find('.switch-xclass, .xclass-title, #editPanels').hide(); // Advanced mode only
+          $(ifrm).contents().find('.switch-xclass, .xclass-title, #editPanels, form#edit #rightPanels').hide(); //Advanced mode only
           $(ifrm).contents().find('div.main').css({
             "left" : "0%",
             "width" : "100%",

--- a/application-xwebide-ui/src/main/resources/WebIDECode/WebIDE_class.xml
+++ b/application-xwebide-ui/src/main/resources/WebIDECode/WebIDE_class.xml
@@ -466,7 +466,7 @@ define(['jquery', 'bootstrap'], function($) {
           $(ifrm).contents().find('#menuview, #rightPanels, #leftPanels, .bottombuttons, #hierarchy, #footerglobal, .row, .leftmenu2').hide();
           $(ifrm).contents().find('#classname').parent().remove();
           $(ifrm).contents().find('#options').find('#updateClassSheet, #updateClassTranslations').attr('checked', false); // Basic mode only
-          $(ifrm).contents().find('.switch-xclass, .xclass-title, #editPanels, form#edit #rightPanels').hide(); //Advanced mode only
+          $(ifrm).contents().find('.switch-xclass, .xclass-title, #editPanels, form#edit #rightPanels').hide(); // Advanced mode only
           $(ifrm).contents().find('div.main').css({
             "left" : "0%",
             "width" : "100%",


### PR DESCRIPTION
Following https://forum.xwiki.org/t/front-end-api-html-ids/16947, we decided to get rid of the `#editPanels` id. There will be a release note about it. 

The change proposed here does not break the extension on old wiki versions, only adds compatibility with the edit page layout from the moment changes in https://github.com/xwiki/xwiki-platform/pull/4140 will be accepted.

Can be reverted if the PR is never accepted in the end (unlikely to happen).